### PR TITLE
add hybrid encryption, make to/from bytes alg-const-time

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -23,3 +23,4 @@ jobs:
           yarn build
       - name: yarn test
         run: |
+          yarn test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,13 @@
 
 ### Unreleased
 
-- add separate best-effort constant-time scalar mul
+- rename package to `@nocturne-xyz/crypto-utils`
+- add module `hybrid-encryption` containing a generic `HybridCipher` 
+- add separate `fromEntropy` method to `PrimeField` for reducing arbitrary `Uint8Array`s into field elements
+- add `toBytes` and `fromBytes` to curve
+- make `ZModPField.toBytes` and `ZModPField.fromBytes` algorithmic constant-time
 - restructure into two sub-modules: `hashes` and `algebra`.
+- add separate best-effort constant-time scalar mul
 - impl Baby JubJub curve using `TwistedEdwardsCurve` abstraction
 - add `TwistedEdwardsCurve` abstraction
 - add `AffineCurve` interface

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Unreleased
 
+- add `NumBytes` to `PrimeField`
 - rename package to `@nocturne-xyz/crypto-utils`
 - add module `hybrid-encryption` containing a generic `HybridCipher` 
 - add separate `fromEntropy` method to `PrimeField` for reducing arbitrary `Uint8Array`s into field elements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@
 - add separate `fromEntropy` method to `PrimeField` for reducing arbitrary `Uint8Array`s into field elements
 - add `toBytes` and `fromBytes` to curve
 - make `ZModPField.toBytes` and `ZModPField.fromBytes` algorithmic constant-time
-- restructure into two sub-modules: `hashes` and `algebra`.
 - add separate best-effort constant-time scalar mul
+- restructure into two sub-modules: `hashes` and `algebra`.
 - impl Baby JubJub curve using `TwistedEdwardsCurve` abstraction
 - add `TwistedEdwardsCurve` abstraction
 - add `AffineCurve` interface

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# circuit-utils
+# crypto-utils
 
 > DISCLAIMER: this library is an ongoing WIP. It currently only contains a subset of circomlibjs' functionality. It hasn't been audited, so use it at your own risk.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nocturne-xyz/crypto-utils",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nocturne-xyz/crypto-utils",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -11,7 +11,7 @@
   "scripts": {
     "build": "tsc --build",
     "check": "tsc --noEmit",
-    "clean": "rm -rf .turbo dist",
+    "clean": "rm -rf dist",
     "lint": "eslint --fix src --ext .ts",
     "test": "mocha --require ts-node/register test/** --exit",
     "prettier:check": "prettier --check ./src ./test",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nocturne-xyz/crypto-utils",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@nocturne-xyz/circuit-utils",
-  "version": "0.1.12",
+  "name": "@nocturne-xyz/crypto-utils",
+  "version": "0.1.0",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -34,5 +34,9 @@
     "prettier": "^2.8.0",
     "ts-node": "^10.9.1",
     "typescript": "^4.8.4"
+  },
+  "dependencies": {
+    "@noble/hashes": "^1.3.1",
+    "@stablelib/chacha20poly1305": "^1.0.1"
   }
 }

--- a/src/algebra/field.ts
+++ b/src/algebra/field.ts
@@ -62,7 +62,7 @@ export interface PrimeField<FieldElement> {
 
 export class ZModPField implements PrimeField<bigint> {
   readonly NumBits: number;
-  readonly NumBytes: number; 
+  readonly NumBytes: number;
   readonly Modulus: bigint;
   readonly Zero: bigint;
   readonly One: bigint;

--- a/src/algebra/field.ts
+++ b/src/algebra/field.ts
@@ -2,6 +2,7 @@ import { assert, bigintToBits } from "../utils";
 
 export interface PrimeField<FieldElement> {
   NumBits: number;
+  NumBytes: number;
   Modulus: FieldElement;
   Zero: FieldElement;
   One: FieldElement;
@@ -61,6 +62,7 @@ export interface PrimeField<FieldElement> {
 
 export class ZModPField implements PrimeField<bigint> {
   readonly NumBits: number;
+  readonly NumBytes: number; 
   readonly Modulus: bigint;
   readonly Zero: bigint;
   readonly One: bigint;
@@ -74,6 +76,7 @@ export class ZModPField implements PrimeField<bigint> {
   constructor(modulus: bigint, twoAdicity: bigint, nonQR: bigint) {
     this.Modulus = modulus;
     this.NumBits = modulus.toString(2).length;
+    this.NumBytes = Math.ceil(this.NumBits / 8);
     this.nonQR = nonQR;
 
     this.twoAdicity = twoAdicity;

--- a/src/hybrid-encryption/index.ts
+++ b/src/hybrid-encryption/index.ts
@@ -1,5 +1,5 @@
-// a Nocturne-specific hybrid encryption scheme that requires the sender to prove knowledge of the ephemeral secret key
-// see [TODO] for a detailed spec and security argument
+// a Nocturne-specific hybrid encryption scheme that requires the sender to prove knowledge of the decapsulated secret
+// see [TODO] for more information
 
 import { sha256 } from "@noble/hashes/sha256";
 import { expand, extract } from "@noble/hashes/hkdf";

--- a/src/hybrid-encryption/index.ts
+++ b/src/hybrid-encryption/index.ts
@@ -122,7 +122,7 @@ export class HybridCipher {
     ikm.set(encapsulatedSecretBytes);
     ikm.set(sharedSecretBytes, encapsulatedSecretBytes.length);
 
-    // decrive ephemeral encryption key from IKM
+    // derive ephemeral encryption key from IKM
     const prk = HKDF_SHA256.extract(ikm);
     const ephemeralKey = HKDF_SHA256.expand(prk, KEY_LENGTH);
 
@@ -136,11 +136,8 @@ export class HybridCipher {
     cipher.clean();
 
     // extract ephemeral secret and msg from plaintext
-    const numEphemeralSecretBytes = Math.ceil(
-      this.curve.ScalarField.NumBits / 8
-    );
-    const ephemeralSecretBytes = plaintext.slice(0, numEphemeralSecretBytes);
-    const msg = plaintext.slice(numEphemeralSecretBytes);
+    const ephemeralSecretBytes = plaintext.slice(0, this.curve.ScalarField.NumBytes);
+    const msg = plaintext.slice(this.curve.ScalarField.NumBytes);
     const ephemeralSecret =
       this.curve.ScalarField.fromBytes(ephemeralSecretBytes);
     if (ephemeralSecret === null) {

--- a/src/hybrid-encryption/index.ts
+++ b/src/hybrid-encryption/index.ts
@@ -18,8 +18,7 @@ export interface HybridCiphertext {
 }
 
 export const HKDF_SHA256: HPKEKDF = {
-  extract: (ikm: Uint8Array, salt?: Uint8Array) =>
-    extract(sha256, ikm, salt),
+  extract: (ikm: Uint8Array, salt?: Uint8Array) => extract(sha256, ikm, salt),
   expand: (prk: Uint8Array, outputLen: number, info?: Uint8Array) =>
     expand(sha256, prk, info, outputLen),
 };

--- a/src/hybrid-encryption/index.ts
+++ b/src/hybrid-encryption/index.ts
@@ -1,0 +1,156 @@
+// a Nocturne-specific hybrid encryption scheme that requires the sender to prove knowledge of the ephemeral secret key
+// see [TODO] for a detailed spec and security argument
+
+import { sha256 } from "@noble/hashes/sha256";
+import { hkdf } from "@noble/hashes/hkdf";
+import { AffineCurve, AffinePoint } from "../algebra";
+import {
+  ChaCha20Poly1305,
+  KEY_LENGTH,
+  NONCE_LENGTH,
+} from "@stablelib/chacha20poly1305";
+import crypto from "crypto";
+
+export interface HybridCiphertext {
+  iv: Uint8Array;
+  ciphertextBytes: Uint8Array;
+  encapsulatedSecretBytes: Uint8Array;
+}
+
+export class HybridCipher {
+  protected curve: AffineCurve<bigint>;
+  protected ephemeralSecretEntropyNumBytes: number;
+
+  // curve is the elliptic curve to use for encryption
+  // ephemeralSecretEntropyNumBytes is the number of bytes of entropy to use for the ephemeral secret key.
+  // The ephemeral secret is derived by interpreting this array as a little-endian number and reducing it modulo the scalar field order,
+  // so the `ephemeralSecretEntropyNumBytes` should be set to a significantly larger value than the scalar field order's byte length
+  // to ensure that the resulting secret key has a close to uniform distribution.
+  constructor(
+    curve: AffineCurve<bigint>,
+    ephemeralSecretEntropyNumBytes: number
+  ) {
+    this.curve = curve;
+    this.ephemeralSecretEntropyNumBytes = ephemeralSecretEntropyNumBytes;
+  }
+
+  // encrypts a message to a given receiver public key rB, where r is the receiver's secret key and B is the curve's base point
+  public encrypt(
+    msg: Uint8Array,
+    receiverPubkey: AffinePoint<bigint>
+  ): HybridCiphertext {
+    // sample ephemeral secret
+    const ephemeralSecretEntropy = crypto.getRandomValues(
+      new Uint8Array(this.ephemeralSecretEntropyNumBytes)
+    );
+    const ephemeralSecret = this.curve.ScalarField.fromEntropy(
+      ephemeralSecretEntropy
+    );
+
+    // construct plaintext: ephemeralSecret || msg
+    const ephemeralSecretBytes =
+      this.curve.ScalarField.toBytes(ephemeralSecret);
+    const plaintext = new Uint8Array(ephemeralSecretBytes.length + msg.length);
+    plaintext.set(ephemeralSecretBytes);
+    plaintext.set(msg, ephemeralSecretBytes.length);
+
+    // encapsulate ephemeral secret
+    const encapsulatedSecret = this.curve.scalarMul(
+      this.curve.BasePoint,
+      ephemeralSecret
+    );
+
+    // compute shared secret
+    const sharedSecret = this.curve.scalarMul(receiverPubkey, ephemeralSecret);
+
+    // derive IKM from shared secret and encapsulated secret
+    const encapsulatedSecretBytes = this.curve.toBytes(encapsulatedSecret);
+    const sharedSecretBytes = this.curve.toBytes(sharedSecret);
+    const ikm = new Uint8Array(
+      encapsulatedSecretBytes.length + sharedSecretBytes.length
+    );
+    ikm.set(encapsulatedSecretBytes);
+    ikm.set(sharedSecretBytes, encapsulatedSecretBytes.length);
+
+    // derive ephemeral encryption key from IKM
+    const ephemeralKey = hkdf(sha256, ikm, undefined, undefined, KEY_LENGTH);
+
+    // encrypt
+    const cipher = new ChaCha20Poly1305(ephemeralKey);
+    const iv = crypto.getRandomValues(new Uint8Array(NONCE_LENGTH));
+    const ciphertextBytes = cipher.seal(iv, plaintext);
+    cipher.clean();
+
+    return {
+      iv,
+      ciphertextBytes,
+      encapsulatedSecretBytes,
+    };
+  }
+
+  decrypt(
+    ciphertext: HybridCiphertext,
+    receiverPrivateKey: bigint
+  ): Uint8Array {
+    const decryptionError = new Error("failed to decrypt");
+
+    // deserialize stuff
+    const { iv, ciphertextBytes, encapsulatedSecretBytes } = ciphertext;
+    if (iv.length !== NONCE_LENGTH) {
+      throw decryptionError;
+    }
+
+    const encapsulatedSecret = this.curve.fromBytes(encapsulatedSecretBytes);
+    if (encapsulatedSecret === null) {
+      throw decryptionError;
+    }
+
+    // compute shared secret
+    const sharedSecret = this.curve.scalarMul(
+      encapsulatedSecret,
+      receiverPrivateKey
+    );
+
+    // derive IKM from shared secret and encapsulated secret
+    const sharedSecretBytes = this.curve.toBytes(sharedSecret);
+    const ikm = new Uint8Array(
+      encapsulatedSecretBytes.length + sharedSecretBytes.length
+    );
+    ikm.set(encapsulatedSecretBytes);
+    ikm.set(sharedSecretBytes, encapsulatedSecretBytes.length);
+
+    // decrive ephemeral encryption key from IKM
+    const ephemeralKey = hkdf(sha256, ikm, undefined, undefined, KEY_LENGTH);
+
+    // decrypt
+    const cipher = new ChaCha20Poly1305(ephemeralKey);
+    const plaintext = cipher.open(iv, ciphertextBytes);
+    if (plaintext === null) {
+      throw decryptionError;
+    }
+    cipher.clean();
+
+    // extract ephemeral secret and msg from plaintext
+    const numEphemeralSecretBytes = Math.ceil(
+      this.curve.ScalarField.NumBits / 8
+    );
+    const ephemeralSecretBytes = plaintext.slice(0, numEphemeralSecretBytes);
+    const msg = plaintext.slice(numEphemeralSecretBytes);
+    const ephemeralSecret =
+      this.curve.ScalarField.fromBytes(ephemeralSecretBytes);
+    if (ephemeralSecret === null) {
+      throw decryptionError;
+    }
+
+    // check ephemeralSecret against encapsulated secret
+    const encapsulatedSecretCheck = this.curve.scalarMul(
+      this.curve.BasePoint,
+      ephemeralSecret
+    );
+    if (!this.curve.eq(encapsulatedSecret, encapsulatedSecretCheck)) {
+      throw decryptionError;
+    }
+
+    return msg;
+  }
+}

--- a/src/hybrid-encryption/index.ts
+++ b/src/hybrid-encryption/index.ts
@@ -136,7 +136,10 @@ export class HybridCipher {
     cipher.clean();
 
     // extract ephemeral secret and msg from plaintext
-    const ephemeralSecretBytes = plaintext.slice(0, this.curve.ScalarField.NumBytes);
+    const ephemeralSecretBytes = plaintext.slice(
+      0,
+      this.curve.ScalarField.NumBytes
+    );
     const msg = plaintext.slice(this.curve.ScalarField.NumBytes);
     const ephemeralSecret =
       this.curve.ScalarField.fromBytes(ephemeralSecretBytes);

--- a/src/hybrid-encryption/nonceDerivation.ts
+++ b/src/hybrid-encryption/nonceDerivation.ts
@@ -57,7 +57,7 @@ export function deriveBaseNonce(
   kdf: HPKEKDF,
   sharedSecret: Uint8Array,
   aeadNonceLen: number,
-  info: Uint8Array = INFO,
+  info: Uint8Array = INFO
 ): Uint8Array {
   const pskIdHash = labeledExtract(kdf, PSK_ID_HASH_LABEL, PSK_ID);
   const infoHash = labeledExtract(kdf, INFO_HASH_LABEL, info);
@@ -108,7 +108,7 @@ function labeledExpand(
   len: number,
   info?: Uint8Array
 ): Uint8Array {
-  if (len > 256**2) {
+  if (len > 256 ** 2) {
     throw new Error("labeledExpand: length too large");
   }
 

--- a/src/hybrid-encryption/nonceDerivation.ts
+++ b/src/hybrid-encryption/nonceDerivation.ts
@@ -108,7 +108,7 @@ function labeledExpand(
   len: number,
   info?: Uint8Array
 ): Uint8Array {
-  if (len > 1n << (8n * 2n)) {
+  if (len > 256**2) {
     throw new Error("labeledExpand: length too large");
   }
 

--- a/src/hybrid-encryption/nonceDerivation.ts
+++ b/src/hybrid-encryption/nonceDerivation.ts
@@ -1,0 +1,133 @@
+// `base_nonce` derivation following HPKE RFC
+import { i2osp } from "../utils";
+
+export interface HPKEKDF {
+  extract(ikm: Uint8Array, salt?: Uint8Array): Uint8Array;
+  expand(prk: Uint8Array, outputLen: number, info?: Uint8Array): Uint8Array;
+}
+
+// mode 0x01: encrypt to public key
+const MODE = i2osp(0x01n, 1);
+
+// b"HPKE-v1"
+const HPKE_V1_LABEL = new Uint8Array([72, 80, 75, 69, 45, 118, 49]);
+
+// b"HPKE"
+const HPKE_LABEL = new Uint8Array([72, 80, 75, 69, 0, 0, 0, 0, 0, 0]);
+
+// b"psk_id_hash"
+export const PSK_ID_HASH_LABEL = new Uint8Array([
+  112, 115, 107, 95, 105, 100, 95, 104, 97, 115, 104,
+]);
+
+// b"info_hash"
+export const INFO_HASH_LABEL = new Uint8Array([
+  105, 110, 102, 111, 95, 104, 97, 115, 104,
+]);
+
+// b"secret"
+const SECRET_LABEL = new Uint8Array([115, 101, 99, 114, 101, 116]);
+
+// b"base_nonce"
+export const BASE_NONCE_LABEL = new Uint8Array([
+  98, 97, 115, 101, 95, 110, 111, 110, 99, 101,
+]);
+
+// KEM using nocturne PKI (a non-spec compliant DHKEM). Not registered.
+const KEM_ID = i2osp(0xffaan, 2);
+// HKDF using SHA256
+const KDF_ID = i2osp(0x0001n, 2);
+// ChaCha20Poly1305
+const AEAD_ID = i2osp(0x0003n, 2);
+
+const SUITE_ID = new Uint8Array(
+  HPKE_LABEL.length + KEM_ID.length + KDF_ID.length + AEAD_ID.length
+);
+SUITE_ID.set(HPKE_LABEL);
+SUITE_ID.set(KEM_ID, HPKE_LABEL.length);
+SUITE_ID.set(KDF_ID, HPKE_LABEL.length + KEM_ID.length);
+SUITE_ID.set(AEAD_ID, HPKE_LABEL.length + KEM_ID.length + KDF_ID.length);
+
+// all empty as we don't need them in our setting
+const PSK_ID = new Uint8Array(0);
+const PSK = new Uint8Array(0);
+const INFO = new Uint8Array(0);
+
+export function deriveBaseNonce(
+  kdf: HPKEKDF,
+  sharedSecret: Uint8Array,
+  aeadNonceLen: number
+): Uint8Array {
+  const pskIdHash = labeledExtract(kdf, PSK_ID_HASH_LABEL, PSK_ID);
+  const infoHash = labeledExtract(kdf, INFO_HASH_LABEL, INFO);
+
+  // concat(mode, psk_id_hash, info_hash)
+  const keyScheduleContext = new Uint8Array(
+    MODE.length + pskIdHash.length + infoHash.length
+  );
+  keyScheduleContext.set(MODE);
+  keyScheduleContext.set(pskIdHash, MODE.length);
+  keyScheduleContext.set(infoHash, MODE.length + pskIdHash.length);
+
+  // LabeledExtract(shared_secret, "secret", psk)
+  const secret = labeledExtract(kdf, SECRET_LABEL, PSK, sharedSecret);
+  return labeledExpand(
+    kdf,
+    BASE_NONCE_LABEL,
+    secret,
+    aeadNonceLen,
+    keyScheduleContext
+  );
+}
+
+function labeledExtract(
+  kdf: HPKEKDF,
+  label: Uint8Array,
+  ikm: Uint8Array,
+  salt?: Uint8Array
+): Uint8Array {
+  // concat("HPKE-v1", suite_id, label, ikm)
+  const labeledIKM = new Uint8Array(
+    HPKE_V1_LABEL.length + SUITE_ID.length + label.length + ikm.length
+  );
+  labeledIKM.set(HPKE_V1_LABEL);
+  labeledIKM.set(SUITE_ID, HPKE_V1_LABEL.length);
+  labeledIKM.set(label, HPKE_V1_LABEL.length + SUITE_ID.length);
+  labeledIKM.set(ikm, HPKE_V1_LABEL.length + SUITE_ID.length + label.length);
+
+  return kdf.extract(labeledIKM, salt);
+}
+
+function labeledExpand(
+  kdf: HPKEKDF,
+  label: Uint8Array,
+  prk: Uint8Array,
+  len: number,
+  info?: Uint8Array
+): Uint8Array {
+  if (len > 1n << (8n * 2n)) {
+    throw new Error("labeledExpand: length too large");
+  }
+
+  // concat(I2OSP(L, 2), "HPKE-v1", suite_id, label, info))
+  const labeledInfo = new Uint8Array(
+    2 +
+      HPKE_V1_LABEL.length +
+      SUITE_ID.length +
+      label.length +
+      (info ? info.length : 0)
+  );
+  labeledInfo.set(i2osp(BigInt(len), 2));
+  labeledInfo.set(HPKE_V1_LABEL, 2);
+  labeledInfo.set(SUITE_ID, 2 + HPKE_V1_LABEL.length);
+  labeledInfo.set(label, 2 + HPKE_V1_LABEL.length + SUITE_ID.length);
+
+  if (info) {
+    labeledInfo.set(
+      info,
+      2 + HPKE_V1_LABEL.length + SUITE_ID.length + label.length
+    );
+  }
+
+  return kdf.expand(prk, len, labeledInfo);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./algebra";
 export * from "./hashes";
+export * from "./hybrid-encryption";

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -53,12 +53,12 @@ export function i2osp(n: bigint, length: number): Uint8Array {
     throw new Error("i2osp: input must be non-negative");
   }
 
-  if (n > 256**length) {
+  if (n > 256 ** length) {
     throw new Error(
       "i2osp: input too large to encode into a byte array of specified length"
     );
   }
- 
+
   const bytes = new Uint8Array(length);
 
   for (let i = length - 1; i >= 0; i--) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -9,11 +9,11 @@ export function uint8ArrayToUnprefixedHex(buf: Uint8Array): string {
 }
 
 export function unprefixedHexToUint8Array(hex: string): Uint8Array {
-  if (hex.length % 2) {
+  if (hex.length % 2 !== 0) {
     hex = "0" + hex;
   }
 
-  const u8 = new Uint8Array(hex.length);
+  const u8 = new Uint8Array(hex.length / 2);
 
   let i = 0;
   let j = 0;
@@ -58,7 +58,7 @@ export function i2osp(n: bigint, length: number): Uint8Array {
       "i2osp: input too large to encode into a byte array of specified length"
     );
   }
-
+ 
   const bytes = new Uint8Array(length);
 
   for (let i = length - 1; i >= 0; i--) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -53,7 +53,7 @@ export function i2osp(n: bigint, length: number): Uint8Array {
     throw new Error("i2osp: input must be non-negative");
   }
 
-  if (n > 1n << BigInt(8 * length)) {
+  if (n > 256**length) {
     throw new Error(
       "i2osp: input too large to encode into a byte array of specified length"
     );

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -45,3 +45,26 @@ export function bigintToBitsNum(value: bigint): number[] {
 
   return bits;
 }
+
+// RFC 3447 - compliant I2OSP
+// converts a non-negative bigint to a big-endian byte string of length `length`
+export function i2osp(n: bigint, length: number): Uint8Array {
+  if (n < 0n) {
+    throw new Error("i2osp: input must be non-negative");
+  }
+
+  if (n > 1n << BigInt(8 * length)) {
+    throw new Error(
+      "i2osp: input too large to encode into a byte array of specified length"
+    );
+  }
+
+  const bytes = new Uint8Array(length);
+
+  for (let i = length - 1; i >= 0; i--) {
+    bytes[i] = Number(n & 0xffn);
+    n >>= 8n;
+  }
+
+  return bytes;
+}

--- a/test/hybridCipher.test.ts
+++ b/test/hybridCipher.test.ts
@@ -58,8 +58,8 @@ describe("HybridCipher", () => {
   });
 });
 
-describe("BaseNonseDerivation", () => {
-  // HACK: before running BaseNonceDerivation tests, manually overwrite KEM_ID to id of DHKEM(X25519) for tests
+describe("deriveBaseNonce", () => {
+  // HACK: before running base nonce derivation tests, manually overwrite KEM_ID to id of DHKEM(X25519) for tests
   // afterwards, put it back
   const DHKEM_X25519_ID = i2osp(0x0020n, 2);
   const KEM_ID_COPY = new Uint8Array(KEM_ID.length);

--- a/test/hybridCipher.test.ts
+++ b/test/hybridCipher.test.ts
@@ -1,0 +1,52 @@
+import "mocha";
+import { expect } from "chai";
+
+import { BabyJubJub } from "../src/algebra/curves";
+import { HybridCipher } from "../src/hybrid-encryption";
+import { randomBigintModP } from "./utils";
+
+const BABYJUBJUB_WIDE_REDUCTION_ENTROPY = 64;
+
+describe("HybridCipher", () => {
+  it("encrypts and decrypts messages", () => {
+    const cipher = new HybridCipher(
+      BabyJubJub,
+      BABYJUBJUB_WIDE_REDUCTION_ENTROPY
+    );
+
+    const msg = "Kaizoku o ni ore wa naru!";
+    const msgBytes = new TextEncoder().encode(msg);
+
+    const receiverPrivateKey = randomBigintModP(BabyJubJub.ScalarField.Modulus);
+    const receiverPublicKey = BabyJubJub.scalarMul(
+      BabyJubJub.BasePoint,
+      receiverPrivateKey
+    );
+
+    const ciphertext = cipher.encrypt(msgBytes, receiverPublicKey);
+    const decrypted = cipher.decrypt(ciphertext, receiverPrivateKey);
+    expect(decrypted).to.deep.equal(msgBytes);
+  });
+
+  it("fails to decrypt ciphertext that has been tampered with", () => {
+    const cipher = new HybridCipher(
+      BabyJubJub,
+      BABYJUBJUB_WIDE_REDUCTION_ENTROPY
+    );
+    const msg = "Kaizoku o ni ore wa naru!";
+    const msgBytes = new TextEncoder().encode(msg);
+
+    const receiverPrivateKey = randomBigintModP(BabyJubJub.ScalarField.Modulus);
+    const receiverPublicKey = BabyJubJub.scalarMul(
+      BabyJubJub.BasePoint,
+      receiverPrivateKey
+    );
+
+    const ciphertext = cipher.encrypt(msgBytes, receiverPublicKey);
+    ciphertext.ciphertextBytes[0] = (ciphertext.ciphertextBytes[0] + 3) % 8;
+
+    expect(() => cipher.decrypt(ciphertext, receiverPrivateKey)).to.throw(
+      "failed to decrypt"
+    );
+  });
+});

--- a/test/hybridCipher.test.ts
+++ b/test/hybridCipher.test.ts
@@ -2,8 +2,10 @@ import "mocha";
 import { expect } from "chai";
 
 import { BabyJubJub } from "../src/algebra/curves";
-import { HybridCipher } from "../src/hybrid-encryption";
+import { HKDF_SHA256, HybridCipher } from "../src/hybrid-encryption";
 import { randomBigintModP } from "./utils";
+import { HPKE_LABEL, KEM_ID, SUITE_ID, deriveBaseNonce } from "../src/hybrid-encryption/nonceDerivation";
+import { i2osp, unprefixedHexToUint8Array } from "../src/utils";
 
 const BABYJUBJUB_WIDE_REDUCTION_ENTROPY = 64;
 
@@ -51,5 +53,29 @@ describe("HybridCipher", () => {
   });
 });
 
-// TODO: test baseNonce derivation
-// destructively overwrite KEM_ID and test against known test vector(s)
+describe("BaseNonseDerivation", () => {
+  // HACK: before running BaseNonceDerivation tests, manually overwrite KEM_ID to id of DHKEM(X25519) for tests
+  // afterwards, put it back
+  const DHKEM_X25519_ID = i2osp(0x0020n, 2);
+  const KEM_ID_COPY = new Uint8Array(KEM_ID.length);
+  KEM_ID_COPY.set(KEM_ID);
+  before(() => {
+    KEM_ID.set(DHKEM_X25519_ID);
+    SUITE_ID.set(DHKEM_X25519_ID, HPKE_LABEL.length);
+  });
+
+  after(() => {
+    KEM_ID.set(KEM_ID_COPY);
+    SUITE_ID.set(KEM_ID_COPY, HPKE_LABEL.length);
+  });
+
+  it("matches base setup information test vector for DHKEM(X25519)", () => {
+    // test vector from https://www.rfc-editor.org/rfc/rfc9180.html#name-base-setup-information-2
+    const info = unprefixedHexToUint8Array("4f6465206f6e2061204772656369616e2055726e");
+    const sharedSecret = unprefixedHexToUint8Array("0bbe78490412b4bbea4812666f7916932b828bba79942424abb65244930d69a7");
+    const baseNonceExpected = unprefixedHexToUint8Array("5c4d98150661b848853b547f");
+    const baseNonce = deriveBaseNonce(HKDF_SHA256, sharedSecret, 12, info);
+
+    expect(baseNonce).to.deep.equal(baseNonceExpected);
+  });
+});

--- a/test/hybridCipher.test.ts
+++ b/test/hybridCipher.test.ts
@@ -4,7 +4,12 @@ import { expect } from "chai";
 import { BabyJubJub } from "../src/algebra/curves";
 import { HKDF_SHA256, HybridCipher } from "../src/hybrid-encryption";
 import { randomBigintModP } from "./utils";
-import { HPKE_LABEL, KEM_ID, SUITE_ID, deriveBaseNonce } from "../src/hybrid-encryption/nonceDerivation";
+import {
+  HPKE_LABEL,
+  KEM_ID,
+  SUITE_ID,
+  deriveBaseNonce,
+} from "../src/hybrid-encryption/nonceDerivation";
 import { i2osp, unprefixedHexToUint8Array } from "../src/utils";
 
 const BABYJUBJUB_WIDE_REDUCTION_ENTROPY = 64;
@@ -71,9 +76,15 @@ describe("BaseNonseDerivation", () => {
 
   it("matches base setup information test vector for DHKEM(X25519)", () => {
     // test vector from https://www.rfc-editor.org/rfc/rfc9180.html#name-base-setup-information-2
-    const info = unprefixedHexToUint8Array("4f6465206f6e2061204772656369616e2055726e");
-    const sharedSecret = unprefixedHexToUint8Array("0bbe78490412b4bbea4812666f7916932b828bba79942424abb65244930d69a7");
-    const baseNonceExpected = unprefixedHexToUint8Array("5c4d98150661b848853b547f");
+    const info = unprefixedHexToUint8Array(
+      "4f6465206f6e2061204772656369616e2055726e"
+    );
+    const sharedSecret = unprefixedHexToUint8Array(
+      "0bbe78490412b4bbea4812666f7916932b828bba79942424abb65244930d69a7"
+    );
+    const baseNonceExpected = unprefixedHexToUint8Array(
+      "5c4d98150661b848853b547f"
+    );
     const baseNonce = deriveBaseNonce(HKDF_SHA256, sharedSecret, 12, info);
 
     expect(baseNonce).to.deep.equal(baseNonceExpected);

--- a/test/hybridCipher.test.ts
+++ b/test/hybridCipher.test.ts
@@ -50,3 +50,6 @@ describe("HybridCipher", () => {
     );
   });
 });
+
+// TODO: test baseNonce derivation
+// destructively overwrite KEM_ID and test against known test vector(s)

--- a/test/hybridCipher.test.ts
+++ b/test/hybridCipher.test.ts
@@ -21,7 +21,7 @@ describe("HybridCipher", () => {
       BABYJUBJUB_WIDE_REDUCTION_ENTROPY
     );
 
-    const msg = "Kaizoku o ni ore wa naru!";
+    const msg = "Kaizoku ou ni ore wa naru!";
     const msgBytes = new TextEncoder().encode(msg);
 
     const receiverPrivateKey = randomBigintModP(BabyJubJub.ScalarField.Modulus);
@@ -40,7 +40,7 @@ describe("HybridCipher", () => {
       BabyJubJub,
       BABYJUBJUB_WIDE_REDUCTION_ENTROPY
     );
-    const msg = "Kaizoku o ni ore wa naru!";
+    const msg = "Kaizoku ou ni ore wa naru!";
     const msgBytes = new TextEncoder().encode(msg);
 
     const receiverPrivateKey = randomBigintModP(BabyJubJub.ScalarField.Modulus);

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,4 +1,4 @@
-import * as crypto from "crypto";
+import crypto from "crypto";
 import { PrimeField } from "../src/algebra/field";
 
 export function range(start: number, stop?: number, step?: number): number[] {
@@ -19,7 +19,7 @@ export function randomFieldElement<FieldElement>(
 ): FieldElement {
   const numBytes = (F.NumBits + 7) / 8;
   const bytes = crypto.randomBytes(numBytes);
-  return F.fromBytes(bytes);
+  return F.fromEntropy(bytes);
 }
 
 export function randomBigintModP(p: bigint): bigint {

--- a/yarn.lock
+++ b/yarn.lock
@@ -107,10 +107,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nocturne-xyz/circuit-utils@workspace:.":
+"@noble/hashes@npm:^1.3.1":
+  version: 1.3.1
+  resolution: "@noble/hashes@npm:1.3.1"
+  checksum: 7fdefc0f7a0c1ec27acc6ff88841793e3f93ec4ce6b8a6a12bfc0dd70ae6b7c4c82fe305fdfeda1735d5ad4a9eebe761e6693b3d355689c559e91242f4bc95b1
+  languageName: node
+  linkType: hard
+
+"@nocturne-xyz/crypto-utils@workspace:.":
   version: 0.0.0-use.local
-  resolution: "@nocturne-xyz/circuit-utils@workspace:."
+  resolution: "@nocturne-xyz/crypto-utils@workspace:."
   dependencies:
+    "@noble/hashes": ^1.3.1
+    "@stablelib/chacha20poly1305": ^1.0.1
     "@types/bn.js": ^5.1.1
     "@types/chai": ^4.3.3
     "@types/mocha": ^10.0.0
@@ -174,6 +183,77 @@ __metadata:
     mkdirp: ^1.0.4
     rimraf: ^3.0.2
   checksum: 52dc02259d98da517fae4cb3a0a3850227bdae4939dda1980b788a7670636ca2b4a01b58df03dd5f65c1e3cb70c50fa8ce5762b582b3f499ec30ee5ce1fd9380
+  languageName: node
+  linkType: hard
+
+"@stablelib/aead@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "@stablelib/aead@npm:1.0.1"
+  checksum: 1a6f68d138f105d17dd65349751515bd252ab0498c77255b8555478d28415600dde493f909eb718245047a993f838dfae546071e1687566ffb7b8c3e10c918d9
+  languageName: node
+  linkType: hard
+
+"@stablelib/binary@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "@stablelib/binary@npm:1.0.1"
+  dependencies:
+    "@stablelib/int": ^1.0.1
+  checksum: dca9b98eb1f56a4002b5b9e7351fbc49f3d8616af87007c01e833bd763ac89214eb5f3b7e18673c91ce59d4a0e4856a2eb661ace33d39f17fb1ad267271fccd8
+  languageName: node
+  linkType: hard
+
+"@stablelib/chacha20poly1305@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "@stablelib/chacha20poly1305@npm:1.0.1"
+  dependencies:
+    "@stablelib/aead": ^1.0.1
+    "@stablelib/binary": ^1.0.1
+    "@stablelib/chacha": ^1.0.1
+    "@stablelib/constant-time": ^1.0.1
+    "@stablelib/poly1305": ^1.0.1
+    "@stablelib/wipe": ^1.0.1
+  checksum: 81f1a32330838d31e4dc3144d76eba7244b56d9ea38c1f604f2c34d93ed8e67e9a6167d2cfd72254c13cc46dfc1f5ce5157b37939a575295d69d9144abb4e4fb
+  languageName: node
+  linkType: hard
+
+"@stablelib/chacha@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "@stablelib/chacha@npm:1.0.1"
+  dependencies:
+    "@stablelib/binary": ^1.0.1
+    "@stablelib/wipe": ^1.0.1
+  checksum: f061f36c4ca4bf177dd7cac11e7c65ced164f141b6065885141ae5a55f32e16ba0209aefcdcc966aef013f1da616ce901a3a80653b4b6f833cf7e3397ae2d6bd
+  languageName: node
+  linkType: hard
+
+"@stablelib/constant-time@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "@stablelib/constant-time@npm:1.0.1"
+  checksum: dba4f4bf508de2ff15f7f0cbd875e70391aa3ba3698290fe1ed2feb151c243ba08a90fc6fb390ec2230e30fcc622318c591a7c0e35dcb8150afb50c797eac3d7
+  languageName: node
+  linkType: hard
+
+"@stablelib/int@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "@stablelib/int@npm:1.0.1"
+  checksum: 65bfbf50a382eea70c68e05366bf379cfceff8fbc076f1c267ef2f2411d7aed64fd140c415cb6c29f19a3910d3b8b7805d4b32ad5721a5007a8e744a808c7ae3
+  languageName: node
+  linkType: hard
+
+"@stablelib/poly1305@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "@stablelib/poly1305@npm:1.0.1"
+  dependencies:
+    "@stablelib/constant-time": ^1.0.1
+    "@stablelib/wipe": ^1.0.1
+  checksum: 70b845bb0481c66b7ba3f3865d01e4c67a4dffc9616fc6de1d23efc5e828ec09de25f8e3be4e1f15a23b8e87e3036ee3d949c2fd4785047e6f7028bbec0ead18
+  languageName: node
+  linkType: hard
+
+"@stablelib/wipe@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "@stablelib/wipe@npm:1.0.1"
+  checksum: 287802eb146810a46ba72af70b82022caf83a8aeebde23605f5ee0decf64fe2b97a60c856e43b6617b5801287c30cfa863cfb0469e7fcde6f02d143cf0c6cbf4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below. Bug fixes and new features should include tests.
-->

## Motivation

Nocturne needs a proper hybrid encryption scheme for note encryption

## Solution

Add one! At a high level, we use the following procedure (separate documentation TODO):

```
Encrypt(msg, R):
   x <- randomFr()
   E <- x*G
   K = KDF(R, E, x*R)
   return (E, AEAD_encrypt(K, x || msg))

Decrypt_r(E, C):
   K = KDF(R, E, r*E)
   m = AEAD_Decrypt(K, C)
   if m == null:
       return None
   x, msg = m[:32], m[32:]
   if x*G != E:
       return None
   else:
       return Some(msg)
```

We encrypt `x || msg` instead of just `msg` to force the sender to prove knowledge of the ephemeral secret, closing a DDH oracle that is present in the way Nocturne avoids extra key management for note encryption.

Two asides:
1. This library is becoming less of a circuit-specific util library and more of a general "crypto utils" for Nocturne, so I also renamed the package.
2. Noticed that the field/curve serialization methods weren't algorithmic constant-time, so I wrote separate "best-effort" (this is javascript after all) algo-constant-time "fromBytes" / "toBytes" for `algebra` primitives.

## PR Checklist

- [X] Added Tests
- [X] Updated CHANGELOG.md